### PR TITLE
fixed namespaces

### DIFF
--- a/Api/CookieGroupRepositoryInterface.php
+++ b/Api/CookieGroupRepositoryInterface.php
@@ -1,11 +1,11 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Api;
+namespace Phpro\CookieConsent\Api;
 
 use Exception;
 use Magento\Framework\Api\SearchCriteriaInterface;
 use Magento\Framework\Api\SearchResultsInterface;
-use PHPro\CookieConsent\Api\Data\CookieGroupInterface;
+use Phpro\CookieConsent\Api\Data\CookieGroupInterface;
 
 interface CookieGroupRepositoryInterface
 {

--- a/Api/Data/CookieGroupInterface.php
+++ b/Api/Data/CookieGroupInterface.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Api\Data;
+namespace Phpro\CookieConsent\Api\Data;
 
 interface CookieGroupInterface
 {

--- a/Api/Data/EavModelInterface.php
+++ b/Api/Data/EavModelInterface.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Api\Data;
+namespace Phpro\CookieConsent\Api\Data;
 
 interface EavModelInterface
 {

--- a/Block/Adminhtml/Store/Edit/BackButton.php
+++ b/Block/Adminhtml/Store/Edit/BackButton.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Block\Adminhtml\Store\Edit;
+namespace Phpro\CookieConsent\Block\Adminhtml\Store\Edit;
 
 use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
 

--- a/Block/Adminhtml/Store/Edit/DeleteButton.php
+++ b/Block/Adminhtml/Store/Edit/DeleteButton.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Block\Adminhtml\Store\Edit;
+namespace Phpro\CookieConsent\Block\Adminhtml\Store\Edit;
 
 use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
 

--- a/Block/Adminhtml/Store/Edit/GenericButton.php
+++ b/Block/Adminhtml/Store/Edit/GenericButton.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Block\Adminhtml\Store\Edit;
+namespace Phpro\CookieConsent\Block\Adminhtml\Store\Edit;
 
 use Magento\Backend\Block\Widget\Context;
 

--- a/Block/Adminhtml/Store/Edit/SaveAndContinueButton.php
+++ b/Block/Adminhtml/Store/Edit/SaveAndContinueButton.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Block\Adminhtml\Store\Edit;
+namespace Phpro\CookieConsent\Block\Adminhtml\Store\Edit;
 
 use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
 

--- a/Block/Adminhtml/Store/Edit/SaveButton.php
+++ b/Block/Adminhtml/Store/Edit/SaveButton.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Block\Adminhtml\Store\Edit;
+namespace Phpro\CookieConsent\Block\Adminhtml\Store\Edit;
 
 use Magento\Framework\View\Element\UiComponent\Control\ButtonProviderInterface;
 

--- a/Block/Widget/Overview.php
+++ b/Block/Widget/Overview.php
@@ -1,16 +1,16 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Block\Widget;
+namespace Phpro\CookieConsent\Block\Widget;
 
 use Magento\Framework\View\Element\Template;
 use Magento\Framework\View\Element\Template\Context;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Widget\Block\BlockInterface;
-use PHPro\CookieConsent\Model\ResourceModel\CookieGroup\CollectionFactory;
+use Phpro\CookieConsent\Model\ResourceModel\CookieGroup\CollectionFactory;
 
 class Overview extends Template implements BlockInterface
 {
-    protected $_template = "PHPro_CookieConsent::widget/overview.phtml";
+    protected $_template = "Phpro_CookieConsent::widget/overview.phtml";
 
     /**
      * @var CollectionFactory

--- a/Block/Widget/Preferences/Button.php
+++ b/Block/Widget/Preferences/Button.php
@@ -1,13 +1,13 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Block\Widget\Preferences;
+namespace Phpro\CookieConsent\Block\Widget\Preferences;
 
 use Magento\Framework\View\Element\Template;
 use Magento\Widget\Block\BlockInterface;
 
 class Button extends Template implements BlockInterface
 {
-    protected $_template = "PHPro_CookieConsent::widget/preferences/button.phtml";
+    protected $_template = "Phpro_CookieConsent::widget/preferences/button.phtml";
 
     public function getButtonType(): int
     {

--- a/Config/CookieConsentConfig.php
+++ b/Config/CookieConsentConfig.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Config;
+namespace Phpro\CookieConsent\Config;
 
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;

--- a/Controller/Adminhtml/CookieGroup/Delete.php
+++ b/Controller/Adminhtml/CookieGroup/Delete.php
@@ -1,16 +1,16 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Controller\Adminhtml\CookieGroup;
+namespace Phpro\CookieConsent\Controller\Adminhtml\CookieGroup;
 
 use Exception;
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
 use Magento\Backend\Model\View\Result\Redirect;
-use PHPro\CookieConsent\Api\CookieGroupRepositoryInterface;
+use Phpro\CookieConsent\Api\CookieGroupRepositoryInterface;
 
 class Delete extends Action
 {
-    const ADMIN_RESOURCE = 'PHPro_CookieConsent::CookieGroup_delete';
+    const ADMIN_RESOURCE = 'Phpro_CookieConsent::CookieGroup_delete';
 
     /**
      * @var CookieGroupRepositoryInterface

--- a/Controller/Adminhtml/CookieGroup/Edit.php
+++ b/Controller/Adminhtml/CookieGroup/Edit.php
@@ -1,19 +1,19 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Controller\Adminhtml\CookieGroup;
+namespace Phpro\CookieConsent\Controller\Adminhtml\CookieGroup;
 
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
 use Magento\Framework\Registry;
 use Magento\Framework\View\Result\PageFactory;
 use Magento\Store\Model\Store;
-use PHPro\CookieConsent\Api\CookieGroupRepositoryInterface;
-use PHPro\CookieConsent\Model\CookieGroup;
-use PHPro\CookieConsent\Model\CookieGroupFactory;
+use Phpro\CookieConsent\Api\CookieGroupRepositoryInterface;
+use Phpro\CookieConsent\Model\CookieGroup;
+use Phpro\CookieConsent\Model\CookieGroupFactory;
 
 class Edit extends Action
 {
-    const ADMIN_RESOURCE = 'PHPro_CookieConsent::CookieGroup_edit';
+    const ADMIN_RESOURCE = 'Phpro_CookieConsent::CookieGroup_edit';
 
     /**
      * @var PageFactory

--- a/Controller/Adminhtml/CookieGroup/Index.php
+++ b/Controller/Adminhtml/CookieGroup/Index.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Controller\Adminhtml\CookieGroup;
+namespace Phpro\CookieConsent\Controller\Adminhtml\CookieGroup;
 
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;
@@ -8,7 +8,7 @@ use Magento\Framework\View\Result\PageFactory;
 
 class Index extends Action
 {
-    const ADMIN_RESOURCE = 'PHPro_CookieConsent::CookieGroup';
+    const ADMIN_RESOURCE = 'Phpro_CookieConsent::CookieGroup';
 
     /**
      * @var PageFactory

--- a/Controller/Adminhtml/CookieGroup/NewAction.php
+++ b/Controller/Adminhtml/CookieGroup/NewAction.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Controller\Adminhtml\CookieGroup;
+namespace Phpro\CookieConsent\Controller\Adminhtml\CookieGroup;
 
 use Magento\Backend\App\Action;
 use Magento\Backend\App\Action\Context;

--- a/Controller/Adminhtml/CookieGroup/Save.php
+++ b/Controller/Adminhtml/CookieGroup/Save.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Controller\Adminhtml\CookieGroup;
+namespace Phpro\CookieConsent\Controller\Adminhtml\CookieGroup;
 
 use Exception;
 use Magento\Backend\App\Action;
@@ -9,14 +9,14 @@ use Magento\Framework\App\Request\DataPersistorInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPro\CookieConsent\Api\CookieGroupRepositoryInterface;
-use PHPro\CookieConsent\Api\Data\CookieGroupInterface;
-use PHPro\CookieConsent\Model\CookieGroup;
-use PHPro\CookieConsent\Model\CookieGroupFactory;
+use Phpro\CookieConsent\Api\CookieGroupRepositoryInterface;
+use Phpro\CookieConsent\Api\Data\CookieGroupInterface;
+use Phpro\CookieConsent\Model\CookieGroup;
+use Phpro\CookieConsent\Model\CookieGroupFactory;
 
 class Save extends Action
 {
-    const ADMIN_RESOURCE = 'PHPro_CookieConsent::CookieGroup_save';
+    const ADMIN_RESOURCE = 'Phpro_CookieConsent::CookieGroup_save';
 
     /**
      * @var DataPersistorInterface

--- a/Helper/AttributesHelper.php
+++ b/Helper/AttributesHelper.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Helper;
+namespace Phpro\CookieConsent\Helper;
 
 use Magento\Eav\Api\AttributeGroupRepositoryInterface;
 use Magento\Eav\Api\AttributeRepositoryInterface;

--- a/Helper/UiComponentHelper.php
+++ b/Helper/UiComponentHelper.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Helper;
+namespace Phpro\CookieConsent\Helper;
 
 use Magento\Backend\Model\UrlInterface;
 use Magento\Eav\Api\Data\AttributeInterface;
@@ -10,8 +10,8 @@ use Magento\Framework\Filesystem;
 use Magento\Framework\Stdlib\ArrayManager;
 use Magento\Framework\View\Asset\Repository;
 use Magento\Store\Model\Store;
-use PHPro\CookieConsent\Api\Data\EavModelInterface;
-use PHPro\CookieConsent\Model\Eav\ScopeOverriddenValue;
+use Phpro\CookieConsent\Api\Data\EavModelInterface;
+use Phpro\CookieConsent\Model\Eav\ScopeOverriddenValue;
 
 class UiComponentHelper
 {

--- a/Model/CookieGroup.php
+++ b/Model/CookieGroup.php
@@ -1,10 +1,10 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Model;
+namespace Phpro\CookieConsent\Model;
 
 use Magento\Framework\Model\AbstractModel;
-use PHPro\CookieConsent\Api\Data\CookieGroupInterface;
-use PHPro\CookieConsent\Api\Data\EavModelInterface;
+use Phpro\CookieConsent\Api\Data\CookieGroupInterface;
+use Phpro\CookieConsent\Api\Data\EavModelInterface;
 
 class CookieGroup extends AbstractModel implements CookieGroupInterface, EavModelInterface
 {

--- a/Model/CookieGroupAttribute.php
+++ b/Model/CookieGroupAttribute.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Model;
+namespace Phpro\CookieConsent\Model;
 
 use Magento\Eav\Model\Attribute;
 

--- a/Model/CookieGroupRepository.php
+++ b/Model/CookieGroupRepository.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Model;
+namespace Phpro\CookieConsent\Model;
 
 use Exception;
 use Magento\Framework\Api\SearchCriteria\CollectionProcessorInterface;
@@ -10,11 +10,11 @@ use Magento\Framework\Api\SearchResultsInterfaceFactory;
 use Magento\Framework\Exception\CouldNotSaveException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Exception\StateException;
-use PHPro\CookieConsent\Api\CookieGroupRepositoryInterface;
-use PHPro\CookieConsent\Api\Data\CookieGroupInterface;
-use PHPro\CookieConsent\Model\ResourceModel\CookieGroup as CookieGroupResourceModel;
-use PHPro\CookieConsent\Model\ResourceModel\CookieGroup\Collection;
-use PHPro\CookieConsent\Model\ResourceModel\CookieGroup\CollectionFactory;
+use Phpro\CookieConsent\Api\CookieGroupRepositoryInterface;
+use Phpro\CookieConsent\Api\Data\CookieGroupInterface;
+use Phpro\CookieConsent\Model\ResourceModel\CookieGroup as CookieGroupResourceModel;
+use Phpro\CookieConsent\Model\ResourceModel\CookieGroup\Collection;
+use Phpro\CookieConsent\Model\ResourceModel\CookieGroup\CollectionFactory;
 
 class CookieGroupRepository implements CookieGroupRepositoryInterface
 {

--- a/Model/Eav/ScopeOverriddenValue.php
+++ b/Model/Eav/ScopeOverriddenValue.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Model\Eav;
+namespace Phpro\CookieConsent\Model\Eav;
 
 use Magento\Eav\Api\AttributeRepositoryInterface as AttributeRepository;
 use Magento\Framework\Api\FilterBuilder;

--- a/Model/ResourceModel/AbstractCollection.php
+++ b/Model/ResourceModel/AbstractCollection.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Model\ResourceModel;
+namespace Phpro\CookieConsent\Model\ResourceModel;
 
 use Magento\Eav\Model\Config;
 use Magento\Eav\Model\Entity\AbstractEntity;

--- a/Model/ResourceModel/AbstractResource.php
+++ b/Model/ResourceModel/AbstractResource.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Model\ResourceModel;
+namespace Phpro\CookieConsent\Model\ResourceModel;
 
 use Magento\Eav\Model\Entity\AbstractEntity;
 use Magento\Eav\Model\Entity\Attribute\UniqueValidationInterface;
@@ -8,7 +8,7 @@ use Magento\Eav\Model\Entity\Context;
 use Magento\Framework\DataObject;
 use Magento\Store\Model\Store;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPro\CookieConsent\Model\CookieGroupFactory;
+use Phpro\CookieConsent\Model\CookieGroupFactory;
 
 abstract class AbstractResource extends AbstractEntity
 {

--- a/Model/ResourceModel/CookieGroup.php
+++ b/Model/ResourceModel/CookieGroup.php
@@ -1,8 +1,8 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Model\ResourceModel;
+namespace Phpro\CookieConsent\Model\ResourceModel;
 
-use PHPro\CookieConsent\Model\CookieGroup as CookieGroupModel;
+use Phpro\CookieConsent\Model\CookieGroup as CookieGroupModel;
 
 class CookieGroup extends AbstractResource
 {

--- a/Model/ResourceModel/CookieGroup/Collection.php
+++ b/Model/ResourceModel/CookieGroup/Collection.php
@@ -1,10 +1,10 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Model\ResourceModel\CookieGroup;
+namespace Phpro\CookieConsent\Model\ResourceModel\CookieGroup;
 
-use PHPro\CookieConsent\Model\CookieGroup as CookieGroupModel;
-use PHPro\CookieConsent\Model\ResourceModel\AbstractCollection;
-use PHPro\CookieConsent\Model\ResourceModel\CookieGroup as CookieGroupResourceModel;
+use Phpro\CookieConsent\Model\CookieGroup as CookieGroupModel;
+use Phpro\CookieConsent\Model\ResourceModel\AbstractCollection;
+use Phpro\CookieConsent\Model\ResourceModel\CookieGroup as CookieGroupResourceModel;
 
 class Collection extends AbstractCollection
 {

--- a/Model/Source/Widget/Button.php
+++ b/Model/Source/Widget/Button.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Model\Source\Widget;
+namespace Phpro\CookieConsent\Model\Source\Widget;
 
 use Magento\Eav\Model\Entity\Attribute\Source\AbstractSource;
 

--- a/Setup/CookieGroupSetup.php
+++ b/Setup/CookieGroupSetup.php
@@ -1,11 +1,11 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Setup;
+namespace Phpro\CookieConsent\Setup;
 
 use Magento\Eav\Setup\EavSetup;
-use PHPro\CookieConsent\Api\Data\CookieGroupInterface;
-use PHPro\CookieConsent\Model\CookieGroupAttribute;
-use PHPro\CookieConsent\Model\ResourceModel\CookieGroup as CookieGroupResourceModel;
+use Phpro\CookieConsent\Api\Data\CookieGroupInterface;
+use Phpro\CookieConsent\Model\CookieGroupAttribute;
+use Phpro\CookieConsent\Model\ResourceModel\CookieGroup as CookieGroupResourceModel;
 
 class CookieGroupSetup extends EavSetup
 {

--- a/Setup/Patch/Data/CookieGroupAttribute.php
+++ b/Setup/Patch/Data/CookieGroupAttribute.php
@@ -1,11 +1,11 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Setup\Patch\Data;
+namespace Phpro\CookieConsent\Setup\Patch\Data;
 
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
-use PHPro\CookieConsent\Setup\CookieGroupSetup;
-use PHPro\CookieConsent\Setup\CookieGroupSetupFactory;
+use Phpro\CookieConsent\Setup\CookieGroupSetup;
+use Phpro\CookieConsent\Setup\CookieGroupSetupFactory;
 
 class CookieGroupAttribute implements DataPatchInterface
 {

--- a/Setup/Patch/Data/DefaultCookieData.php
+++ b/Setup/Patch/Data/DefaultCookieData.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Setup\Patch\Data;
+namespace Phpro\CookieConsent\Setup\Patch\Data;
 
 use Magento\Cms\Api\BlockRepositoryInterface;
 use Magento\Cms\Api\PageRepositoryInterface;
@@ -8,9 +8,9 @@ use Magento\Cms\Model\BlockFactory;
 use Magento\Cms\Model\PageFactory;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Magento\Store\Model\Store;
-use PHPro\CookieConsent\Api\CookieGroupRepositoryInterface;
-use PHPro\CookieConsent\Api\Data\CookieGroupInterface;
-use PHPro\CookieConsent\Model\CookieGroupFactory;
+use Phpro\CookieConsent\Api\CookieGroupRepositoryInterface;
+use Phpro\CookieConsent\Api\Data\CookieGroupInterface;
+use Phpro\CookieConsent\Model\CookieGroupFactory;
 
 class DefaultCookieData implements DataPatchInterface
 {
@@ -126,8 +126,8 @@ class DefaultCookieData implements DataPatchInterface
         $page->setTitle('Cookie Consent Overview');
         $page->setIdentifier('consent-overview');
         $page->setContentHeading('Cookie Consent Overview');
-        $page->setContent('<p>{{widget type="PHPro\CookieConsent\Block\Widget\Overview"}}</p>' . PHP_EOL .
-            '<p>{{widget type="PHPro\CookieConsent\Block\Widget\Preferences\Button" preferences_button_type="0"}}</p>');
+        $page->setContent('<p>{{widget type="Phpro\CookieConsent\Block\Widget\Overview"}}</p>' . PHP_EOL .
+            '<p>{{widget type="Phpro\CookieConsent\Block\Widget\Preferences\Button" preferences_button_type="0"}}</p>');
 
         $this->pageRepository->save($page);
     }

--- a/Ui/Component/Listing/Column/CookieGroupActions.php
+++ b/Ui/Component/Listing/Column/CookieGroupActions.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Ui\Component\Listing\Column;
+namespace Phpro\CookieConsent\Ui\Component\Listing\Column;
 
 use Magento\Framework\UrlInterface;
 use Magento\Framework\View\Element\UiComponent\ContextInterface;

--- a/Ui/DataProvider/CookieGroup/Form/DataProvider.php
+++ b/Ui/DataProvider/CookieGroup/Form/DataProvider.php
@@ -1,15 +1,15 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Ui\DataProvider\CookieGroup\Form;
+namespace Phpro\CookieConsent\Ui\DataProvider\CookieGroup\Form;
 
 use Magento\Framework\App\RequestInterface;
 use Magento\Store\Model\Store;
 use Magento\Ui\DataProvider\AbstractDataProvider;
 use Magento\Ui\DataProvider\Modifier\ModifierInterface;
 use Magento\Ui\DataProvider\Modifier\PoolInterface;
-use PHPro\CookieConsent\Api\CookieGroupRepositoryInterface;
-use PHPro\CookieConsent\Api\Data\CookieGroupInterface;
-use PHPro\CookieConsent\Model\ResourceModel\CookieGroup\CollectionFactory;
+use Phpro\CookieConsent\Api\CookieGroupRepositoryInterface;
+use Phpro\CookieConsent\Api\Data\CookieGroupInterface;
+use Phpro\CookieConsent\Model\ResourceModel\CookieGroup\CollectionFactory;
 
 class DataProvider extends AbstractDataProvider
 {

--- a/Ui/DataProvider/CookieGroup/Form/Modifier/Fields.php
+++ b/Ui/DataProvider/CookieGroup/Form/Modifier/Fields.php
@@ -1,17 +1,17 @@
 <?php
 declare(strict_types=1);
 
-namespace PHPro\CookieConsent\Ui\DataProvider\CookieGroup\Form\Modifier;
+namespace Phpro\CookieConsent\Ui\DataProvider\CookieGroup\Form\Modifier;
 
 use Magento\Eav\Model\Entity\Attribute;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Registry;
 use Magento\Framework\UrlInterface;
 use Magento\Ui\DataProvider\Modifier\ModifierInterface;
-use PHPro\CookieConsent\Helper\AttributesHelper;
-use PHPro\CookieConsent\Helper\UiComponentHelper;
-use PHPro\CookieConsent\Model\CookieGroup;
-use PHPro\CookieConsent\Model\CookieGroupFactory;
+use Phpro\CookieConsent\Helper\AttributesHelper;
+use Phpro\CookieConsent\Helper\UiComponentHelper;
+use Phpro\CookieConsent\Model\CookieGroup;
+use Phpro\CookieConsent\Model\CookieGroupFactory;
 
 /**
  * Class Fields

--- a/ViewModel/Cookie.php
+++ b/ViewModel/Cookie.php
@@ -1,13 +1,13 @@
 <?php declare(strict_types=1);
 
-namespace PHPro\CookieConsent\ViewModel;
+namespace Phpro\CookieConsent\ViewModel;
 
 use Magento\Framework\Stdlib\CookieManagerInterface;
 use Magento\Framework\View\Element\Block\ArgumentInterface;
 use Magento\Store\Model\StoreManagerInterface;
-use PHPro\CookieConsent\Api\Data\CookieGroupInterface;
-use PHPro\CookieConsent\Config\CookieConsentConfig;
-use PHPro\CookieConsent\Model\ResourceModel\CookieGroup\CollectionFactory;
+use Phpro\CookieConsent\Api\Data\CookieGroupInterface;
+use Phpro\CookieConsent\Config\CookieConsentConfig;
+use Phpro\CookieConsent\Model\ResourceModel\CookieGroup\CollectionFactory;
 
 class Cookie implements ArgumentInterface
 {

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -5,10 +5,10 @@
         <resources>
             <resource id="Magento_Backend::admin">
                 <resource id="Magento_Customer::customer">
-                    <resource id="PHPro_CookieConsent::cookie_consent" title="Cookie Consent">
-                        <resource id="PHPro_CookieConsent::configuration" title="Configuration" translate="title" />
-                        <resource id="PHPro_CookieConsent::cookie_consent_cookie_groups" title="Cookie Groups"/>
-                        <resource id="PHPro_CookieConsent::cookie_consent_cookies" title="Cookie"/>
+                    <resource id="Phpro_CookieConsent::cookie_consent" title="Cookie Consent">
+                        <resource id="Phpro_CookieConsent::configuration" title="Configuration" translate="title" />
+                        <resource id="Phpro_CookieConsent::cookie_consent_cookie_groups" title="Cookie Groups"/>
+                        <resource id="Phpro_CookieConsent::cookie_consent_cookies" title="Cookie"/>
                     </resource>
                 </resource>
             </resource>

--- a/etc/adminhtml/di.xml
+++ b/etc/adminhtml/di.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
-    <virtualType name="PHPro\CookieConsent\DataProvider\Modifier\CookieGroupPool" type="Magento\Ui\DataProvider\Modifier\Pool">
+    <virtualType name="Phpro\CookieConsent\DataProvider\Modifier\CookieGroupPool" type="Magento\Ui\DataProvider\Modifier\Pool">
         <arguments>
             <argument name="modifiers" xsi:type="array">
                 <item name="eav_fields_modifier" xsi:type="array">
-                    <item name="class" xsi:type="string">PHPro\CookieConsent\Ui\DataProvider\CookieGroup\Form\Modifier\Fields</item>
+                    <item name="class" xsi:type="string">Phpro\CookieConsent\Ui\DataProvider\CookieGroup\Form\Modifier\Fields</item>
                     <item name="sortOrder" xsi:type="number">10</item>
                 </item>
             </argument>
         </arguments>
     </virtualType>
-    <type name="PHPro\CookieConsent\Ui\DataProvider\CookieGroup\Form\DataProvider">
+    <type name="Phpro\CookieConsent\Ui\DataProvider\CookieGroup\Form\DataProvider">
         <arguments>
-            <argument name="modifiersPool" xsi:type="object">PHPro\CookieConsent\DataProvider\Modifier\CookieGroupPool</argument>
+            <argument name="modifiersPool" xsi:type="object">Phpro\CookieConsent\DataProvider\Modifier\CookieGroupPool</argument>
         </arguments>
     </type>
 </config>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Backend:etc/menu.xsd">
     <menu>
-        <add id="PHPro_CookieConsent::cookie_consent" title="Cookie Consent" translate="title" module="PHPro_CookieConsent" sortOrder="50" parent="Magento_Customer::customer" resource="PHPro_CookieConsent::cookie_consent"/>
-        <add id="PHPro_CookieConsent::cookie_groups" title="Cookie Groups" module="PHPro_CookieConsent" sortOrder="10" parent="PHPro_CookieConsent::cookie_consent" resource="PHPro_CookieConsent::cookie_consent_cookie_groups" action="phpro_cookie_consent/cookiegroup/index"/>
+        <add id="Phpro_CookieConsent::cookie_consent" title="Cookie Consent" translate="title" module="Phpro_CookieConsent" sortOrder="50" parent="Magento_Customer::customer" resource="Phpro_CookieConsent::cookie_consent"/>
+        <add id="Phpro_CookieConsent::cookie_groups" title="Cookie Groups" module="Phpro_CookieConsent" sortOrder="10" parent="Phpro_CookieConsent::cookie_consent" resource="Phpro_CookieConsent::cookie_consent_cookie_groups" action="phpro_cookie_consent/cookiegroup/index"/>
     </menu>
 </config>

--- a/etc/adminhtml/routes.xml
+++ b/etc/adminhtml/routes.xml
@@ -2,7 +2,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:App/etc/routes.xsd">
     <router id="admin">
         <route frontName="phpro_cookie_consent" id="phpro_cookie_consent">
-            <module name="PHPro_CookieConsent"/>
+            <module name="Phpro_CookieConsent"/>
         </route>
     </router>
 </config>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -5,7 +5,7 @@
         <section id="phpro_cookie_consent" translate="label" sortOrder="130" showInDefault="1" showInWebsite="1" showInStore="1">
             <label>Cookie Consent</label>
             <tab>general</tab>
-            <resource>PHPro_CookieConsent::configuration</resource>
+            <resource>Phpro_CookieConsent::configuration</resource>
             <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>General</label>
                 <field id="enabled" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -2,16 +2,16 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <!-- Start Service Contracts -->
-    <preference for="PHPro\CookieConsent\Api\CookieGroupRepositoryInterface" type="PHPro\CookieConsent\Model\CookieGroupRepository"/>
-    <preference for="PHPro\CookieConsent\Api\Data\CookieGroupInterface" type="PHPro\CookieConsent\Model\CookieGroup"/>
+    <preference for="Phpro\CookieConsent\Api\CookieGroupRepositoryInterface" type="Phpro\CookieConsent\Model\CookieGroupRepository"/>
+    <preference for="Phpro\CookieConsent\Api\Data\CookieGroupInterface" type="Phpro\CookieConsent\Model\CookieGroup"/>
     <!-- End Service Contracts -->
 
     <!-- Start Virtual types -->
     <!-- virtual type for grid collection filled with cookie group models for use in ui component -->
-    <virtualType name="PHPro\CookieConsent\Model\ResourceModel\CookieGroup\Grid\Collection" type="Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult">
+    <virtualType name="Phpro\CookieConsent\Model\ResourceModel\CookieGroup\Grid\Collection" type="Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult">
         <arguments>
             <argument name="mainTable" xsi:type="string">phpro_cc_cookie_group_entity</argument>
-            <argument name="resourceModel" xsi:type="string">PHPro\CookieConsent\Model\ResourceModel\CookieGroup\Collection</argument>
+            <argument name="resourceModel" xsi:type="string">Phpro\CookieConsent\Model\ResourceModel\CookieGroup\Collection</argument>
         </arguments>
     </virtualType>
     <!-- End Virtual types -->
@@ -20,7 +20,7 @@
     <type name="Magento\Framework\EntityManager\MetadataPool">
         <arguments>
             <argument name="metadata" xsi:type="array">
-                <item name="PHPro\CookieConsent\Api\Data\CookieGroupInterface" xsi:type="array">
+                <item name="Phpro\CookieConsent\Api\Data\CookieGroupInterface" xsi:type="array">
                     <item name="entityTableName" xsi:type="string">phpro_cc_cookie_group_entity</item>
                     <item name="eavEntityType" xsi:type="string">phpro_cc_cookie_group</item>
                     <item name="identifierField" xsi:type="string">entity_id</item>
@@ -28,7 +28,7 @@
             </argument>
         </arguments>
     </type>
-    <type name="PHPro\CookieConsent\Model\CookieGroupRepository">
+    <type name="Phpro\CookieConsent\Model\CookieGroupRepository">
         <arguments>
             <argument name="collectionProcessor" xsi:type="object">Magento\Eav\Model\Api\SearchCriteria\CollectionProcessor</argument>
         </arguments>
@@ -37,7 +37,7 @@
     <type name="Magento\Framework\View\Element\UiComponent\DataProvider\CollectionFactory">
         <arguments>
             <argument name="collections" xsi:type="array">
-                <item name="phpro_cookie_consent_listing_data_source" xsi:type="string">PHPro\CookieConsent\Model\ResourceModel\CookieGroup\Grid\Collection</item>
+                <item name="phpro_cookie_consent_listing_data_source" xsi:type="string">Phpro\CookieConsent\Model\ResourceModel\CookieGroup\Grid\Collection</item>
             </argument>
         </arguments>
     </type>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="PHPro_CookieConsent" setup_version="1.0.0" />
+    <module name="Phpro_CookieConsent" setup_version="1.0.0" />
 </config>

--- a/etc/widget.xml
+++ b/etc/widget.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <widgets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Widget:etc/widget.xsd">
-    <widget id="phpro_cookie_consent_overview" class="PHPro\CookieConsent\Block\Widget\Overview">
+    <widget id="phpro_cookie_consent_overview" class="Phpro\CookieConsent\Block\Widget\Overview">
         <label translate="true">Cookie consent overview</label>
         <description translate="true">Listing of cookie groups</description>
     </widget>
-    <widget id="phpro_cookie_preferences_button" class="PHPro\CookieConsent\Block\Widget\Preferences\Button">
+    <widget id="phpro_cookie_preferences_button" class="Phpro\CookieConsent\Block\Widget\Preferences\Button">
         <label translate="true">Cookie preferences button</label>
         <description translate="true">Button to open the cookie preferences modal</description>
         <parameters>
-            <parameter name="preferences_button_type" xsi:type="select" required="true" visible="true" source_model="PHPro\CookieConsent\Model\Source\Widget\Button">
+            <parameter name="preferences_button_type" xsi:type="select" required="true" visible="true" source_model="Phpro\CookieConsent\Model\Source\Widget\Button">
                 <label>Button/Link</label>
             </parameter>
         </parameters>

--- a/registration.php
+++ b/registration.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 \Magento\Framework\Component\ComponentRegistrar::register(
     \Magento\Framework\Component\ComponentRegistrar::MODULE,
-    'PHPro_CookieConsent',
+    'Phpro_CookieConsent',
     __DIR__
 );

--- a/view/adminhtml/ui_component/phpro_cookie_consent_cookie_group_form.xml
+++ b/view/adminhtml/ui_component/phpro_cookie_consent_cookie_group_form.xml
@@ -9,10 +9,10 @@
     </argument>
     <settings>
         <buttons>
-            <button class="PHPro\CookieConsent\Block\Adminhtml\Store\Edit\BackButton" name="back"/>
-            <button class="PHPro\CookieConsent\Block\Adminhtml\Store\Edit\DeleteButton" name="delete"/>
-            <button class="PHPro\CookieConsent\Block\Adminhtml\Store\Edit\SaveButton" name="save"/>
-            <button class="PHPro\CookieConsent\Block\Adminhtml\Store\Edit\SaveAndContinueButton"
+            <button class="Phpro\CookieConsent\Block\Adminhtml\Store\Edit\BackButton" name="back"/>
+            <button class="Phpro\CookieConsent\Block\Adminhtml\Store\Edit\DeleteButton" name="delete"/>
+            <button class="Phpro\CookieConsent\Block\Adminhtml\Store\Edit\SaveButton" name="save"/>
+            <button class="Phpro\CookieConsent\Block\Adminhtml\Store\Edit\SaveAndContinueButton"
                     name="save_and_continue"/>
         </buttons>
         <namespace>phpro_cookie_consent_cookie_group_form</namespace>
@@ -30,7 +30,7 @@
         <settings>
             <submitUrl path="*/*/save"/>
         </settings>
-        <dataProvider class="PHPro\CookieConsent\Ui\DataProvider\CookieGroup\Form\DataProvider" name="cookie_group_form_data_source">
+        <dataProvider class="Phpro\CookieConsent\Ui\DataProvider\CookieGroup\Form\DataProvider" name="cookie_group_form_data_source">
             <settings>
                 <requestFieldName>entity_id</requestFieldName>
                 <primaryFieldName>entity_id</primaryFieldName>

--- a/view/adminhtml/ui_component/phpro_cookie_consent_cookie_group_listing.xml
+++ b/view/adminhtml/ui_component/phpro_cookie_consent_cookie_group_listing.xml
@@ -81,7 +81,7 @@
                 </item>
             </argument>
         </column>
-        <actionsColumn class="PHPro\CookieConsent\Ui\Component\Listing\Column\CookieGroupActions" name="actions">
+        <actionsColumn class="Phpro\CookieConsent\Ui\Component\Listing\Column\CookieGroupActions" name="actions">
             <argument name="data" xsi:type="array">
                 <item name="sortOrder" xsi:type="number">80</item>
                 <item name="config" xsi:type="array">

--- a/view/adminhtml/web/css/source/_module.less
+++ b/view/adminhtml/web/css/source/_module.less
@@ -1,5 +1,5 @@
 .admin__menu [data-ui-id="menu-phpro-cookieconsent-cookie-consent"] .submenu-group-title span:before {
-  background-image: url("../PHPro_CookieConsent/images/phpro-logo-menu.png");
+  background-image: url("../Phpro_CookieConsent/images/phpro-logo-menu.png");
   background-repeat: no-repeat;
   background-size: contain;
   width: 50px;

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -4,20 +4,20 @@
         <referenceContainer name="before.body.end">
             <block class="Magento\Framework\View\Element\Template"
                    name="phpro_cookie_consent_notice"
-                   template="PHPro_CookieConsent::notice.phtml"
+                   template="Phpro_CookieConsent::notice.phtml"
                    ifconfig="phpro_cookie_consent/general/enabled"
                    after="-">
                 <arguments>
-                    <argument name="view_model" xsi:type="object">PHPro\CookieConsent\ViewModel\Cookie</argument>
+                    <argument name="view_model" xsi:type="object">Phpro\CookieConsent\ViewModel\Cookie</argument>
                 </arguments>
             </block>
             <block class="Magento\Framework\View\Element\Template"
                    name="phpro_cookie_consent_modal"
-                   template="PHPro_CookieConsent::modal/preferences.phtml"
+                   template="Phpro_CookieConsent::modal/preferences.phtml"
                    ifconfig="phpro_cookie_consent/general/enabled"
                    before="phpro_cookie_consent_notice">
                 <arguments>
-                    <argument name="view_model" xsi:type="object">PHPro\CookieConsent\ViewModel\Cookie</argument>
+                    <argument name="view_model" xsi:type="object">Phpro\CookieConsent\ViewModel\Cookie</argument>
                 </arguments>
             </block>
         </referenceContainer>

--- a/view/frontend/templates/modal/preferences.phtml
+++ b/view/frontend/templates/modal/preferences.phtml
@@ -1,5 +1,5 @@
 <?php
-/** @var \PHPro\CookieConsent\ViewModel\Cookie $viewModel */
+/** @var \Phpro\CookieConsent\ViewModel\Cookie $viewModel */
 $viewModel = $block->getViewModel();
 $cookieGroups = $viewModel->getCookieGroups();
 ?>
@@ -49,7 +49,7 @@ $cookieGroups = $viewModel->getCookieGroups();
 <script type="text/x-magento-init">
 {
     "*": {
-        "PHPro_CookieConsent/js/modal/preferences": {
+        "Phpro_CookieConsent/js/modal/preferences": {
             "cookie_name": "<?= $viewModel->getCookieName(); ?>",
             "expiration": <?= $viewModel->getExpirationDays(); ?>,
             "secure": <?= $viewModel->isFrontUrlSecure(); ?>,

--- a/view/frontend/templates/notice.phtml
+++ b/view/frontend/templates/notice.phtml
@@ -1,5 +1,5 @@
 <?php
-/** @var \PHPro\CookieConsent\ViewModel\Cookie $viewModel */
+/** @var \Phpro\CookieConsent\ViewModel\Cookie $viewModel */
 $viewModel = $block->getViewModel();
 ?>
 <div class="phpro-cookie-notice" style="display: none;">
@@ -21,7 +21,7 @@ $viewModel = $block->getViewModel();
 <script type="text/x-magento-init">
 {
     "*": {
-        "PHPro_CookieConsent/js/notice": {
+        "Phpro_CookieConsent/js/notice": {
             "cookie_name": "<?= $viewModel->getCookieName(); ?>",
             "expiration": <?= $viewModel->getExpirationDays(); ?>,
             "secure": <?= $viewModel->isFrontUrlSecure(); ?>,

--- a/view/frontend/templates/widget/overview.phtml
+++ b/view/frontend/templates/widget/overview.phtml
@@ -1,5 +1,5 @@
 <?php
-/** @var \PHPro\CookieConsent\Block\Widget\Overview $block */
+/** @var \Phpro\CookieConsent\Block\Widget\Overview $block */
 $cookieGroups = $block->getCookieGroups();
 ?>
 <div class="cookie-consent-overview">

--- a/view/frontend/templates/widget/preferences/button.phtml
+++ b/view/frontend/templates/widget/preferences/button.phtml
@@ -1,5 +1,5 @@
 <?php
-/** @var \PHPro\CookieConsent\Block\Widget\Preferences\Button $block */
+/** @var \Phpro\CookieConsent\Block\Widget\Preferences\Button $block */
 $buttonType = $block->getButtonType();
 ?>
 <?php if ($buttonType === 0): ?>

--- a/view/frontend/web/js/modal/preferences.js
+++ b/view/frontend/web/js/modal/preferences.js
@@ -1,6 +1,6 @@
 define([
     'jquery',
-    'PHPro_CookieConsent/js/model/cookie'
+    'Phpro_CookieConsent/js/model/cookie'
 ], function ($, cookie) {
     return function (options) {
         const consentContentElement = '#modal-consent-content';

--- a/view/frontend/web/js/notice.js
+++ b/view/frontend/web/js/notice.js
@@ -1,6 +1,6 @@
 define([
     'jquery',
-    'PHPro_CookieConsent/js/model/cookie'
+    'Phpro_CookieConsent/js/model/cookie'
 ], function ($, cookie) {
     return function (options) {
         if (!cookie.consentCookieExists(options.cookie_name)) {


### PR DESCRIPTION
A problem occurred when running setup:upgrade. The namespaces & module name do not match with the psr-4 autoload the composer.json file. This is a fix where the namespaces & module name have been changed.