### PR TITLE
XANB2C-895 fix error on setup:upgrade

### DIFF
--- a/Setup/Patch/Data/CookieGroupAttribute.php
+++ b/Setup/Patch/Data/CookieGroupAttribute.php
@@ -2,6 +2,7 @@
 
 namespace Phpro\CookieConsent\Setup\Patch\Data;
 
+use Magento\Eav\Model\Config;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\Patch\DataPatchInterface;
 use Phpro\CookieConsent\Setup\CookieGroupSetup;
@@ -19,12 +20,19 @@ class CookieGroupAttribute implements DataPatchInterface
      */
     private $cookieGroupSetupFactory;
 
+    /**
+     * @var Config
+     */
+    private $eavConfig;
+
     public function __construct(
         ModuleDataSetupInterface $moduleDataSetup,
-        CookieGroupSetupFactory $cookieGroupSetupFactory
+        CookieGroupSetupFactory $cookieGroupSetupFactory,
+        Config $eavConfig
     ) {
         $this->moduleDataSetup = $moduleDataSetup;
         $this->cookieGroupSetupFactory = $cookieGroupSetupFactory;
+        $this->eavConfig = $eavConfig;
     }
 
     public static function getDependencies()
@@ -43,5 +51,6 @@ class CookieGroupAttribute implements DataPatchInterface
         $cookieGroupSetup = $this->cookieGroupSetupFactory->create(['setup' => $this->moduleDataSetup]);
 
         $cookieGroupSetup->installEntities();
+	$this->eavConfig->clear();
     }
 }


### PR DESCRIPTION
Following error during first setup:upgrade:
![image](https://user-images.githubusercontent.com/1506882/103632163-31fd8200-4f44-11eb-8be3-17d1bff4abb6.png)

clearing de attribute config cache fixes this issue
